### PR TITLE
ci: read Go version from go.mod

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -5,11 +5,11 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
-
-      - uses: actions/checkout@v6
+          go-version-file: go.mod
 
       - uses: ko-build/setup-ko@v0.9
 

--- a/.github/workflows/golint.yaml
+++ b/.github/workflows/golint.yaml
@@ -9,7 +9,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version-file: go.mod
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version-file: go.mod
 
       - name: Install dependencies
         run: go mod download

--- a/limiter.go
+++ b/limiter.go
@@ -29,9 +29,15 @@ type RateLimitConfig struct {
 	DefaultLimit RateLimit   `yaml:"defaultLimit"`
 }
 
+const (
+	kindPod         = "Pod"
+	kindDeployment  = "Deployment"
+	kindStatefulSet = "StatefulSet"
+)
+
 var (
 	rateLimitConfig RateLimitConfig
-	knownKinds      = []string{"Pod", "Deployment", "StatefulSet"}
+	knownKinds      = []string{kindPod, kindDeployment, kindStatefulSet}
 )
 
 func LoadRateLimitConfig() {
@@ -101,7 +107,7 @@ func ValidatingHandler(w http.ResponseWriter, r *http.Request) {
 	kind := review.Request.Kind.Kind
 
 	switch kind {
-	case "Pod":
+	case kindPod:
 		var pod corev1.Pod
 		if err := json.Unmarshal(review.Request.Object.Raw, &pod); err != nil {
 			http.Error(w, "Error parsing pod spec: "+err.Error(), http.StatusBadRequest)
@@ -109,7 +115,7 @@ func ValidatingHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		name = pod.Name
 		labels = pod.Labels
-	case "Deployment":
+	case kindDeployment:
 		var deployment appsv1.Deployment
 		if err := json.Unmarshal(review.Request.Object.Raw, &deployment); err != nil {
 			http.Error(w, "Error parsing deployment spec: "+err.Error(), http.StatusBadRequest)
@@ -117,7 +123,7 @@ func ValidatingHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		name = deployment.Name
 		labels = deployment.Spec.Template.Labels
-	case "StatefulSet":
+	case kindStatefulSet:
 		var statefulSet appsv1.StatefulSet
 		if err := json.Unmarshal(review.Request.Object.Raw, &statefulSet); err != nil {
 			http.Error(w, "Error parsing statefulset spec: "+err.Error(), http.StatusBadRequest)

--- a/limiter_test.go
+++ b/limiter_test.go
@@ -17,13 +17,17 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-const appLabel = "app"
+const (
+	appLabel     = "app"
+	testName     = "test"
+	validatePath = "/validate"
+)
 
 func TestCreateLimiters(t *testing.T) {
 	rateLimitConfig = RateLimitConfig{
 		Rules: []RateLimit{
 			{
-				Labels:     map[string]string{appLabel: "test"},
+				Labels:     map[string]string{appLabel: testName},
 				Kinds:      []string{kindPod},
 				RatePerSec: 1,
 				Burst:      5,
@@ -45,7 +49,7 @@ func TestGetLimiter(t *testing.T) {
 	rateLimitConfig = RateLimitConfig{
 		Rules: []RateLimit{
 			{
-				Labels:     map[string]string{appLabel: "test"},
+				Labels:     map[string]string{appLabel: testName},
 				Kinds:      []string{kindPod},
 				RatePerSec: 1,
 				Burst:      5,
@@ -69,7 +73,7 @@ func TestGetLimiter(t *testing.T) {
 		{
 			name:            "Matching rule",
 			kind:            kindPod,
-			labels:          map[string]string{appLabel: "test"},
+			labels:          map[string]string{appLabel: testName},
 			expectedError:   false,
 			expectedLimiter: rateLimitConfig.Rules[0].Limiter,
 		},
@@ -118,7 +122,7 @@ func TestValidatingHandler(t *testing.T) {
 			Name: "test-pod-1",
 		},
 		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{{Name: "test", Image: "test"}},
+			Containers: []corev1.Container{{Name: testName, Image: testName}},
 		},
 	}
 	rawPod, err := json.Marshal(pod)
@@ -137,7 +141,7 @@ func TestValidatingHandler(t *testing.T) {
 	}
 
 	// First request should be allowed
-	req := httptest.NewRequest("POST", "/validate", bytes.NewBuffer(body))
+	req := httptest.NewRequest(http.MethodPost, validatePath, bytes.NewBuffer(body))
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusOK, rr.Code)
@@ -147,7 +151,7 @@ func TestValidatingHandler(t *testing.T) {
 	assert.True(t, response.Response.Allowed)
 
 	// Without sleeping, try to create another pod and ensure it is denied
-	req = httptest.NewRequest("POST", "/validate", bytes.NewBuffer(body))
+	req = httptest.NewRequest(http.MethodPost, validatePath, bytes.NewBuffer(body))
 	rr = httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusOK, rr.Code)
@@ -157,7 +161,7 @@ func TestValidatingHandler(t *testing.T) {
 
 	// Sleep for 120ms, try to create another pod and ensure it is allowed
 	time.Sleep(120 * time.Millisecond)
-	req = httptest.NewRequest("POST", "/validate", bytes.NewBuffer(body))
+	req = httptest.NewRequest(http.MethodPost, validatePath, bytes.NewBuffer(body))
 	rr = httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusOK, rr.Code)

--- a/limiter_test.go
+++ b/limiter_test.go
@@ -17,18 +17,20 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+const appLabel = "app"
+
 func TestCreateLimiters(t *testing.T) {
 	rateLimitConfig = RateLimitConfig{
 		Rules: []RateLimit{
 			{
-				Labels:     map[string]string{"app": "test"},
-				Kinds:      []string{"Pod"},
+				Labels:     map[string]string{appLabel: "test"},
+				Kinds:      []string{kindPod},
 				RatePerSec: 1,
 				Burst:      5,
 			},
 		},
 		DefaultLimit: RateLimit{
-			Kinds:      []string{"Pod", "Deployment"},
+			Kinds:      []string{kindPod, kindDeployment},
 			RatePerSec: 0.5,
 			Burst:      3,
 		},
@@ -43,14 +45,14 @@ func TestGetLimiter(t *testing.T) {
 	rateLimitConfig = RateLimitConfig{
 		Rules: []RateLimit{
 			{
-				Labels:     map[string]string{"app": "test"},
-				Kinds:      []string{"Pod"},
+				Labels:     map[string]string{appLabel: "test"},
+				Kinds:      []string{kindPod},
 				RatePerSec: 1,
 				Burst:      5,
 			},
 		},
 		DefaultLimit: RateLimit{
-			Kinds:      []string{"Pod", "Deployment"},
+			Kinds:      []string{kindPod, kindDeployment},
 			RatePerSec: 0.5,
 			Burst:      3,
 		},
@@ -66,14 +68,14 @@ func TestGetLimiter(t *testing.T) {
 	}{
 		{
 			name:            "Matching rule",
-			kind:            "Pod",
-			labels:          map[string]string{"app": "test"},
+			kind:            kindPod,
+			labels:          map[string]string{appLabel: "test"},
 			expectedError:   false,
 			expectedLimiter: rateLimitConfig.Rules[0].Limiter,
 		},
 		{
 			name:            "Default limit",
-			kind:            "Deployment",
+			kind:            kindDeployment,
 			labels:          map[string]string{},
 			expectedError:   false,
 			expectedLimiter: rateLimitConfig.DefaultLimit.Limiter,
@@ -103,7 +105,7 @@ func TestGetLimiter(t *testing.T) {
 func TestValidatingHandler(t *testing.T) {
 	rateLimitConfig = RateLimitConfig{
 		DefaultLimit: RateLimit{
-			Kinds:      []string{"Pod"},
+			Kinds:      []string{kindPod},
 			RatePerSec: 10,
 			Burst:      1,
 		},
@@ -125,7 +127,7 @@ func TestValidatingHandler(t *testing.T) {
 	}
 	review := admissionv1.AdmissionReview{
 		Request: &admissionv1.AdmissionRequest{
-			Kind:   metav1.GroupVersionKind{Kind: "Pod"},
+			Kind:   metav1.GroupVersionKind{Kind: kindPod},
 			Object: runtime.RawExtension{Raw: rawPod},
 		},
 	}


### PR DESCRIPTION
The workflows pinned go-version: "1.24", which fails when a dependency
update (e.g. Dependabot bumps of k8s.io/api to 0.36.x) raises the go
directive past 1.24. Use go-version-file: go.mod so the toolchain
tracks the module's required version automatically.

Also reorder e2e steps so checkout runs before setup-go, since the
latter now needs go.mod on disk.